### PR TITLE
Support pagination in Device.all

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,6 +33,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Transform perform_later to perform_now when testing
+  config.active_job.queue_adapter     = :inline
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
@@ -43,4 +46,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Test app for test
+  ENV['MDMA_APP_GROUP_ID'] = '21708'
 end

--- a/config/initializers/simple_mdm.rb
+++ b/config/initializers/simple_mdm.rb
@@ -1,1 +1,2 @@
 SimpleMDM.api_key = Rails.application.credentials.dig :simple_mdm, :key
+SimpleMDM.api_key ||= ENV['SIMPLEMDM_API_KEY']

--- a/config/initializers/simplemdm.rb
+++ b/config/initializers/simplemdm.rb
@@ -1,11 +1,29 @@
 # Extend SimpleMDM Ruby API to support refresh
 module SimpleMDM
-  # Adds the refresh method to SimpleMDM::Device
   class Device < Base
+    # Adds the refresh method to SimpleMDM::Device
     def refresh
       raise "You cannot refresh device that hasn't been created yet." if new?
       hash, code = fetch("devices/#{id}/refresh", :post)
       code == 202
+    end
+
+    # Overwrites the fetch method to go through each page.
+    def self.all
+      devices = []
+      starting_after = nil
+      more_pages = true
+
+      while more_pages
+        params = { limit: 100, starting_after: starting_after }.compact
+        resp = RestClient.get "#{SimpleMDM.api_url}devices", params: params
+        hash = JSON.parse(resp)
+        devices += hash['data'].collect { |d| build d }
+        starting_after = hash['data'].last['id']
+        more_pages = hash['has_more']
+      end
+
+      devices
     end
   end
 end

--- a/spec/system/devices_spec.rb
+++ b/spec/system/devices_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe 'The devices page', :logged_in do
+  before { visit devices_url }
+
+  context 'given I click on Refresh Devices' do
+    before { click_on 'Refresh devices' }
+
+    it 'displays devices' do
+      expect(page).to have_css 'tbody tr'
+    end
+  end
+end


### PR DESCRIPTION
According to the [SimpleMDM API documentation](https://simplemdm.com/docs/api/#pagination):

> Pagination functionality became available on August 15, 2018.
> Accounts created before this date have until November 15, 2018
> to update their integrations to support pagination.
> On November 15, 2018, pagination will become forced.