### PR TITLE
Fix tests

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,8 +4,8 @@
     "postdeploy": "bundle exec rails db:migrate && bundle exec rails r 'Timeslot.create! if Timeslot.none?'"
   },
   "env": {
-    "MDMA_APP_GROUP_ID": "21708",
-    "MDMA_APP_ID": "55475",
+    "MDMA_APP_GROUP_ID": "21707",
+    "MDMA_APP_ID": "91051",
     "MDMA_APP_IDENTIFIER": "com.clutter.UglySweater",
     "RAILS_MASTER_KEY": {
       "required": true

--- a/app/helpers/manifest_helper.rb
+++ b/app/helpers/manifest_helper.rb
@@ -2,7 +2,8 @@
 module ManifestHelper
   def manifest_url(manifest)
     return unless manifest.attached?
+
     blob_url = rails_blob_url manifest, disposition: 'attachment'
-    "itms-services://?action=download-manifest&url=#{CGI.escape manifest.blob.service_url(expires_in: 1.week)}"
+    "itms-services://?action=download-manifest&url=#{CGI.escape blob_url}"
   end
 end

--- a/app/jobs/generate_manifest_job.rb
+++ b/app/jobs/generate_manifest_job.rb
@@ -65,6 +65,11 @@ private
   end
 
   def package_url
-    CGI::escapeHTML @build.package.blob.service_url(expires_in: 1.week)
+    ActiveStorage::Current.host = 'localhost:3000' if local?
+    CGI.escapeHTML @build.package.blob.service_url(expires_in: 1.week)
+  end
+
+  def local?
+    Rails.application.config.active_storage.service.in? %i[local test]
   end
 end

--- a/app/views/devices/index.html.erb
+++ b/app/views/devices/index.html.erb
@@ -12,7 +12,8 @@
       <tr>
         <th scope="row">
           <span style="white-space: nowrap">
-            <%= pluralize devices.count, 'device' %> on version <%= version %>
+            <%= pluralize devices.count, 'device' %>
+            <%= version ? "on version #{version}" : "with no app" %>
           </span>
         </th>
         <td>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Test app for development
-  ENV['MDMA_APP_GROUP_ID'] = '21708'
-  ENV['MDMA_APP_ID'] = '55475'
+  ENV['MDMA_APP_GROUP_ID'] = '21707'
+  ENV['MDMA_APP_ID'] = '91051'
   ENV['MDMA_APP_IDENTIFIER'] = 'com.clutter.UglySweater'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,5 +48,5 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # Test app for test
-  ENV['MDMA_APP_GROUP_ID'] = '21708'
+  ENV['MDMA_APP_GROUP_ID'] = '21707'
 end


### PR DESCRIPTION
- Update test app ID and group ID to reflect recent changes from SimpleMDM data.
- Display devices with version: nil as "with no app"
- Use Rails URL helper, not direct links to S3

Direct links to S3 expire every week, but Rails URLs don't.

In development and test we don't use S3, so I added a workaround
to use the local service with the host set to localhost:3000.

This will technically work and make the tests pass.
Realistically we will never install an app from localhost.