### PR TITLE
Get more than 10 installed apps per device

### DIFF
--- a/config/initializers/simplemdm.rb
+++ b/config/initializers/simplemdm.rb
@@ -25,5 +25,23 @@ module SimpleMDM
 
       devices
     end
+
+    # Overwrites the fetch method to go through each page.
+    def installed_apps
+      installed_apps = []
+      starting_after = nil
+      more_pages = true
+
+      while more_pages
+        params = { limit: 100, starting_after: starting_after }.compact
+        resp = RestClient.get "#{SimpleMDM.api_url}devices/#{id}/installed_apps", params: params
+        hash = JSON.parse(resp)
+        installed_apps.concat hash['data']
+        more_pages = hash['has_more']
+        starting_after = hash['data'].last['id'] if more_pages
+      end
+
+      installed_apps.map { |app| InstalledApp.build app }
+    end
   end
 end


### PR DESCRIPTION
The original implementation of `device.installed_apps` does not
paginate, so only the first 10 installed apps are fetched:
https://github.com/SimpleMDM/simplemdm-ruby/blob/0606edf1e1c26d7377ce425170f5ea2c598d3232/lib/simplemdm/device.rb#L35-L41

This commit monkey-patches the method to add pagination