### PR TITLE
Fetch devices with Heroku Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ How it works
 The app is hosted on Heroku and relies on one job run by Heroku Scheduler every 10 minutes.
 `bundle exec rake deploys:enqueue` checks whether any build needs to be deployed soon and adds to the queue.
 
+A separate job is run on Heroku Scheduler every day.
+`bundle exec rake devices:fetch` fetches the list of devices with the latest app version.
+
 How to delete a build
 =====================
 

--- a/lib/tasks/fetch_devices.rake
+++ b/lib/tasks/fetch_devices.rake
@@ -1,0 +1,7 @@
+namespace :devices do
+  # Meant to run every day with Heroku Scheduler
+  desc 'Fetch the list of the devices to check the version of the installed app'
+  task fetch: :environment do
+    FetchDevicesJob.perform_later
+  end
+end


### PR DESCRIPTION
Add a rake task so we can run every day through the scheduler.

After deploy:
- [ ] Add `bundle exec rake devices:fetch` to Heroku Scheduler on a daily basis