### PR TITLE
Display app logo in navbar if present

### DIFF
--- a/app/helpers/menu_helper.rb
+++ b/app/helpers/menu_helper.rb
@@ -18,4 +18,12 @@ module MenuHelper
       safe_join [icon, name]
     end
   end
+
+  def navbar_brand
+    if ENV['LOGO_URL']
+      image_tag ENV['LOGO_URL'], alt: 'mdma', width: 30, height: 30, style: 'border-radius: 5px'
+    else
+      'mdma'
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,9 @@
 <body>
   <div class="container">
     <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
-      <span class="navbar-brand">mdma</span>
+      <span class="navbar-brand">
+        <%= navbar_brand %>
+      </span>
       <% if logged_in? %>
         <ul class="navbar-nav mr-auto">
           <%= nav_link_to 'Show builds', root_path, icon: 'archive' %>


### PR DESCRIPTION
If ENV['LOGO_URL'] is set to the URL of the logo of the app
(or any square image), then it will be displayed in the navbar.

This helps distinguish between multiple instances of the app.