### PR TITLE
Ignore devices with no device_name

### DIFF
--- a/app/jobs/deploy_job.rb
+++ b/app/jobs/deploy_job.rb
@@ -90,7 +90,8 @@ private
   end
 
   def should_push?(deploy, device)
-    deploy.includes_device_named?(device.device_name) &&
+    device.device_name &&
+      deploy.includes_device_named?(device.device_name) &&
       device.device_group_id.in?(app_group.device_group_ids) &&
       device.status == 'enrolled'
   end


### PR DESCRIPTION
Stems from https://app.honeybadger.io/projects/54770/faults/49261743
If a single device has no name (e.g. was just added to SimpleMDM)
then the job should not fail.