### PR TITLE
Add a task to update phones to latest app version

### DIFF
--- a/config/initializers/simplemdm.rb
+++ b/config/initializers/simplemdm.rb
@@ -44,4 +44,12 @@ module SimpleMDM
       installed_apps.map { |app| InstalledApp.build app }
     end
   end
+
+  class AppGroup < Base
+    def update_apps
+      hash, code = fetch("assignment_groups/#{id}/update_apps", :post)
+
+      code == 202
+    end
+  end
 end

--- a/lib/tasks/update_apps.rake
+++ b/lib/tasks/update_apps.rake
@@ -1,0 +1,7 @@
+namespace :app_groups do
+  # Meant to run every night with Heroku Scheduler
+  desc 'Sends a request to all phones in the app group to update to the latest version of the app'
+  task update_apps: :environment do
+    SimpleMDM::AppGroup.new(id: ENV['MDMA_APP_GROUP_ID']).update_apps
+  end
+end


### PR DESCRIPTION
This adds a rake task, which allows a scheduled update of all phones in the app group to the latest version of the app on SimpleMDM.