### PR TITLE
Disable "Install" link after a week

### DIFF
--- a/app/jobs/generate_manifest_job.rb
+++ b/app/jobs/generate_manifest_job.rb
@@ -66,7 +66,7 @@ private
 
   def package_url
     ActiveStorage::Current.host = 'localhost:3000' if local?
-    CGI.escapeHTML @build.package.blob.service_url(expires_in: 1.week)
+    CGI.escapeHTML @build.package.blob.service_url(expires_in: Build::MANIFEST_EXPIRES_IN)
   end
 
   def local?

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -26,6 +26,12 @@ class Build < ActiveRecord::Base
     GenerateManifestJob.perform_later self
   end
 
+  MANIFEST_EXPIRES_IN = 1.week
+
+  def has_valid_manifest?
+    manifest.attached? && (manifest.attachment.created_at + MANIFEST_EXPIRES_IN).future?
+  end
+
 private
 
   def validate_future_date

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -17,7 +17,7 @@
           on <%= l build.deploy_at.in_time_zone, format: :verbose %>
         </td>
         <td></td>
-        <% if build.manifest.attached? %>
+        <% if build.has_valid_manifest? %>
         <td>
           <%= link_to 'Install', manifest_url(build.manifest), class: "btn btn-link" %>
         </td>


### PR DESCRIPTION
Closes #152 -- S3 only allows signed URLs to last for a week,
so after a week we cannot let clients install old versions of
the apps directly from mdma.