### PR TITLE
Add a new public API endpoint listing builds

### DIFF
--- a/app/controllers/api/builds_controller.rb
+++ b/app/controllers/api/builds_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  # Returns the list of builds
+  class BuildsController < ActionController::API
+    def index
+      @builds = Build.includes(deploys: :timeslot).order(deploy_at: :desc)
+      render json: @builds.as_json(only: %i[version deploy_at], include: {
+        deploys: {only: %i[status], include: {
+          timeslot: {only: %i[prefixes delay_in_hours]}
+        }
+      }})
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,8 @@ Rails.application.routes.draw do
   resources :fetches, only: %i[create]
   resources :deploys, only: %i[destroy]
   root to: 'builds#index'
+
+  namespace :api, constraints: {format: 'json'} do
+    resources :builds, only: %i[index]
+  end
 end


### PR DESCRIPTION
The idea is to provide third-party clients with an easy way to
learn which builds were deployed and when.

The endpoint is purposely unauthenticated for simplicity of access.
No sensitive data is disclosed.