### PR TITLE
Announce builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In order to use `mdma`, the following environment variables need to be set:
 The following environment variables are optional:
 
 - `GITHUB_PROJECT`: The GitHub "username/project" path to fetch release notes from
-- `SLACK_CHANNEL`: The Slack channel to post notifications to (defaults to #deploys)
+- `SLACK_DEPLOY_CHANNEL`: The Slack channel to post deploys to
 
 For completeness, these are the credentials stored in the app:
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following environment variables are optional:
 
 - `GITHUB_PROJECT`: The GitHub "username/project" path to fetch release notes from
 - `SLACK_DEPLOY_CHANNEL`: The Slack channel to post deploys to
+- `SLACK_BUILD_CHANNEL`: The Slack channel to post builds to
 
 For completeness, these are the credentials stored in the app:
 

--- a/app/jobs/announce_build_job.rb
+++ b/app/jobs/announce_build_job.rb
@@ -1,0 +1,19 @@
+require 'slack'
+
+# Announces on Slack the creation of a new build.
+class AnnounceBuildJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(build)
+    return if ENV['SLACK_BUILD_CHANNEL'].blank?
+
+    app_name = "#{app.name} (#{build.version})"
+    Slack.notify "A new build of #{app_name} is available.", channel: ENV['SLACK_BUILD_CHANNEL']
+  end
+
+private
+
+  def app
+    @app ||= SimpleMDM::App.find(ENV['MDMA_APP_ID'])
+  end
+end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -24,6 +24,7 @@ class Build < ActiveRecord::Base
 
   after_create_commit prepend: true do
     GenerateManifestJob.perform_later self
+    AnnounceBuildJob.perform_later self
   end
 
   MANIFEST_EXPIRES_IN = 1.week

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -2,10 +2,10 @@ require 'rest-client'
 
 # Slack.notify sends a notification to Slack about deploys
 class Slack
-  def self.notify(message)
+  def self.notify(message, channel: ENV['SLACK_CHANNEL'])
     credentials = Rails.application.credentials.dig(:slack, :token_url)
     payload = { 'text' => message }
-    payload['channel'] = ENV['SLACK_CHANNEL'] if ENV['SLACK_CHANNEL'].present?
+    payload['channel'] = channel if channel.present?
     RestClient.post credentials, payload.to_json, content_type: :json, accept: :json
   end
 end

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -2,7 +2,7 @@ require 'rest-client'
 
 # Slack.notify sends a notification to Slack about deploys
 class Slack
-  def self.notify(message, channel: ENV['SLACK_CHANNEL'])
+  def self.notify(message, channel: ENV['SLACK_DEPLOY_CHANNEL'])
     credentials = Rails.application.credentials.dig(:slack, :token_url)
     payload = { 'text' => message }
     payload['channel'] = channel if channel.present?


### PR DESCRIPTION
Partial tackles #26 

As soon as a build is created, a Slack notification is created:

<img width="371" alt="Screen Shot 2019-09-13 at 10 12 00 AM" src="https://user-images.githubusercontent.com/32649767/64881202-fc29e100-d60e-11e9-80b2-1c7e41337896.png" style="border: 1px solid black">

The Slack channel for this notification can be different from the Slack channel of the deploy notification. It can be set with `ENV["SLACK_BUILD_CHANNEL"]` (while the other one can be set with `ENV["SLACK_DEPLOY_CHANNEL"]`.

This feature can be improved in future PRs by also listing the builds, the URL for the attachment, the timeslots.