### PR TITLE
Allow uploading QA builds

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -1,9 +1,9 @@
-# Displays the latest build and shows a form to create new ones.
+# Displays the latest external builds and shows a form to create new ones.
 class BuildsController < ApplicationController
   before_action :require_authentication
 
   def index
-    @builds = Build.with_attached_package.with_attached_manifest.includes(deploys: :timeslot).order(deploy_at: :desc)
+    @builds = Build.external.with_attachments.includes(deploys: :timeslot).order(deploy_at: :desc)
   end
 
   def new

--- a/app/controllers/internal_builds_controller.rb
+++ b/app/controllers/internal_builds_controller.rb
@@ -1,0 +1,8 @@
+# Displays the latest internal builds and shows a form to create new ones.
+class InternalBuildsController < ApplicationController
+  before_action :require_authentication
+
+  def index
+    @builds = Build.internal.with_attachments.order(version: :desc)
+  end
+end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -6,6 +6,11 @@ class Build < ActiveRecord::Base
 
   has_many :deploys, -> { joins(:timeslot).order 'timeslots.delay_in_hours' }, dependent: :destroy
 
+  scope :external, -> { where.not(deploy_at: nil) }
+  scope :internal, -> { where(deploy_at: nil) }
+
+  scope :with_attachments, -> { with_attached_package.with_attached_manifest }
+
   attr_accessor :deploy_date, :deploy_time
   validates :version, presence: true, uniqueness: true
   validate on: :create do

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -7,20 +7,14 @@ class Build < ActiveRecord::Base
   has_many :deploys, -> { joins(:timeslot).order 'timeslots.delay_in_hours' }, dependent: :destroy
 
   attr_accessor :deploy_date, :deploy_time
-  validates :version, :deploy_date, :deploy_time, presence: true, on: :create
-  validates :version, uniqueness: true
+  validates :version, presence: true, uniqueness: true
   validate on: :create do
     validate_future_date if deploy_date.present?
     validate_future_time if deploy_time.present?
   end
 
-  before_create do
-    self.deploy_at ||= deploy_date + deploy_time.seconds_since_midnight.seconds
-  end
-
-  before_create do
-    self.deploys = Timeslot.enabled.map { |timeslot| Deploy.new timeslot: timeslot }
-  end
+  before_create :set_deploy_at, if: -> { deploy_date.present? && deploy_time.present? }
+  before_create :create_deploys, if: -> { deploy_at.present? }
 
   after_create_commit prepend: true do
     GenerateManifestJob.perform_later self
@@ -46,5 +40,13 @@ private
     errors.add :deploy_time, 'must be in the future' if deploy_date == Time.zone.today && deploy_time < Time.zone.now
   rescue ArgumentError
     errors.add :deploy_time, 'has an invalid format'
+  end
+
+  def set_deploy_at
+    self.deploy_at ||= deploy_date + deploy_time.seconds_since_midnight.seconds
+  end
+
+  def create_deploys
+    self.deploys = Timeslot.enabled.map { |timeslot| Deploy.new timeslot: timeslot }
   end
 end

--- a/app/views/builds/new.html.erb
+++ b/app/views/builds/new.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: @build) do |form| %>
-  <%= fieldset "1. Select a file to upload for #{ENV['MDMA_APP_IDENTIFIER']}" do %>
+  <%= fieldset "1. Choose a file to upload for #{ENV['MDMA_APP_IDENTIFIER']}" do %>
     <div class="form-group">
       <%= form.label :package, 'Choose the .ipa package for this build:', class: 'sr-only' %>
       <% if @build.errors[:package].any? %>
@@ -11,18 +11,21 @@
     </div>
   <% end %>
 
-  <%= fieldset "2. Indicate a version, date, and time to deploy in #{Time.zone.name}" do %>
+  <%= fieldset "2. Specify the version" do %>
+    <div class="form-group">
+      <%= form.label :version, class: 'sr-only' %>
+      <% if @build.errors[:version].any? %>
+        <%= form.text_field :version, class: 'form-control is-invalid', placeholder: 'Version' %>
+        <div class="invalid-feedback"><%= @build.errors.full_messages_for(:version).to_sentence %>.</div>
+      <% else %>
+        <%= form.text_field :version, class: 'form-control', placeholder: 'Version' %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= fieldset "3. For external builds only, choose a date and time to deploy in #{Time.zone.name}" do %>
     <div class="form-row">
-      <div class="form-group col-md-4">
-        <%= form.label :version, class: 'sr-only' %>
-        <% if @build.errors[:version].any? %>
-          <%= form.text_field :version, class: 'form-control is-invalid', placeholder: 'Version' %>
-          <div class="invalid-feedback"><%= @build.errors.full_messages_for(:version).to_sentence %>.</div>
-        <% else %>
-          <%= form.text_field :version, class: 'form-control', placeholder: 'Version' %>
-        <% end %>
-      </div>
-      <div class="form-group col-md-4">
+      <div class="form-group col-md-6">
         <%= form.label :deploy_date, class: 'sr-only' %>
         <% if @build.errors[:deploy_date].any? %>
           <%= form.date_field :deploy_date, class: 'form-control is-invalid' %>
@@ -31,7 +34,7 @@
           <%= form.date_field :deploy_date, class: 'form-control' %>
         <% end %>
       </div>
-      <div class="form-group col-md-4">
+      <div class="form-group col-md-6">
         <%= form.label :deploy_time, class: 'sr-only' %>
         <% if @build.errors[:deploy_time].any? %>
           <%= form.time_field :deploy_time, class: 'form-control is-invalid' %>

--- a/app/views/internal_builds/index.html.erb
+++ b/app/views/internal_builds/index.html.erb
@@ -1,0 +1,26 @@
+<% content_for(:refresh) { refresh_button_to 'Enqueue pending', enqueues_path } %>
+<table class="table table-sm">
+  <thead>
+    <tr>
+      <th>Version</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @builds.each do |build| %>
+      <tr class="table-default">
+        <td><%= build.version %></td>
+        <% if build.has_valid_manifest? %>
+        <td>
+          <%= link_to 'Install', manifest_url(build.manifest), class: "btn btn-link" %>
+        </td>
+        <% else %>
+        <td>
+          <%= link_to 'Download', rails_blob_url(build.package, disposition: 'attachment') %>
+        </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,9 +21,10 @@
       </span>
       <% if logged_in? %>
         <ul class="navbar-nav mr-auto">
-          <%= nav_link_to 'Show builds', root_path, icon: 'archive' %>
-          <%= nav_link_to 'Show devices', devices_path, icon: 'mobile' %>
-          <%= nav_link_to 'Show timeslots', timeslots_path, icon: 'clock' %>
+          <%= nav_link_to 'External builds', root_path, icon: 'truck' %>
+          <%= nav_link_to 'Internal builds', internal_builds_path, icon: 'wrench' %>
+          <%= nav_link_to 'Devices', devices_path, icon: 'mobile' %>
+          <%= nav_link_to 'Timeslots', timeslots_path, icon: 'clock' %>
           <%= nav_link_to 'Upload new build', new_build_path, icon: 'cloud-upload-alt' %>
         </ul>
         <%= yield :refresh %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     get 'auth', on: :member
   end
   resources :builds, only: %i[new create]
+  resources :internal_builds, only: %i[index]
   resources :enqueues, only: %i[create]
   resources :devices, only: %i[index]
   resources :timeslots, only: %i[index]


### PR DESCRIPTION
- Separates version from deploy_at in new build form
- Only creates deploys when deploy_date is present
- Show separate QA builds tab

## Pivotal Tracker tickets
[Replace Fabric deployments with mdma](https://www.pivotaltracker.com/story/show/168941731)

## Screenshots
<details>
<summary>Upload new build</summary>
<img alt="Upload new build" src="https://user-images.githubusercontent.com/2874864/66879057-7d0f2c00-ef71-11e9-9742-b9362d7522e8.png">
</details>

<details>
<summary>Show QA builds</summary>
<img alt="Show QA builds" src="https://user-images.githubusercontent.com/2874864/66879059-7d0f2c00-ef71-11e9-90b0-bc28f0500c71.png">
</details>

<details>
<summary>Show release builds</summary>
<img alt="Show release builds" src="https://user-images.githubusercontent.com/2874864/66879060-7d0f2c00-ef71-11e9-8a3f-26780ea26f18.png">
</details>
