### PR TITLE
Change default deploy_time to 03:00

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -7,7 +7,7 @@ class BuildsController < ApplicationController
   end
 
   def new
-    @build = Build.new deploy_time: Time.strptime('20:00', '%H:%M')
+    @build = Build.new deploy_time: Time.strptime('03:00', '%H:%M')
   end
 
   def create

--- a/spec/system/upload_spec.rb
+++ b/spec/system/upload_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Uploading a build', :logged_in, :running_jobs do
 
     it 'displays the deploy' do
       expect(page).to have_text(version)
-      expect(page).to have_text('on Thursday, March 12, 2020 at 8:00PM PDT')
+      expect(page).to have_text('on Thursday, March 12, 2020 at 3:00AM PDT')
       expect(page).to have_link('Install')
     end
 


### PR DESCRIPTION
When we used multiple time slots, our default `deploy_time` was 20:00. Now that we use a single time slot, we have been manually updating the `deploy_time` to 03:00 the next day. This PR changes the default `deploy_time` to match our new process.