### PR TITLE
Redirect to internal builds after creating one

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -14,7 +14,7 @@ class BuildsController < ApplicationController
     @build = Build.new(build_params)
 
     if @build.save
-      redirect_to root_url
+      redirect_to @build.external? ? root_url : internal_builds_url
     else
       render :new
     end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -19,7 +19,7 @@ class Build < ActiveRecord::Base
   end
 
   before_create :set_deploy_at, if: -> { deploy_date.present? && deploy_time.present? }
-  before_create :create_deploy, if: -> { deploy_at.present? }
+  before_create :create_deploy, if: :external?
 
   after_create_commit prepend: true do
     GenerateManifestJob.perform_later self
@@ -29,6 +29,10 @@ class Build < ActiveRecord::Base
 
   def has_valid_manifest?
     manifest.attached? && (manifest.attachment.created_at + MANIFEST_EXPIRES_IN).future?
+  end
+
+  def external?
+    deploy_at.present?
   end
 
 private


### PR DESCRIPTION
After creating a new internal build, you’re redirected to the list of internal builds instead of the list of external builds.