### PR TITLE
Add Ability to Upload a Build Through a New API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ The app is hosted on Heroku and relies on one job run by Heroku Scheduler every 
 A separate job is run on Heroku Scheduler every day.
 `bundle exec rake devices:fetch` fetches the list of devices with the latest app version.
 
+A third-party client can be used to make a request to upload a build. This can be used in place of the web interface in order to do things like upload a build automatically after a GitHub action is triggered. To use this functionality, the `MDMA_TOKEN` environment variable must be set. An example request is shown below.
+
+```
+curl -X POST \
+  -H "Authorization: Token token=[mdma_token]" \
+  -H "Content-Type: multipart/form-data" \
+  -F "package=@[ipa_path]" \
+  -F "title=\"[title]\"" \
+  http://[host]/api/builds
+ ```
+
 How to contribute
 =================
 
@@ -52,6 +63,7 @@ The following environment variables are optional:
 
 - `GITHUB_PROJECT`: The GitHub "username/project" path to fetch release notes from
 - `SLACK_CHANNEL`: The Slack channel to post notifications to (defaults to #deploys)
+- `MDMA_TOKEN`: The key required for a third-party client to make a request to upload a build
 
 For completeness, these are the credentials stored in the app:
 

--- a/app/controllers/api/builds_controller.rb
+++ b/app/controllers/api/builds_controller.rb
@@ -1,0 +1,41 @@
+# Allows a third-party client to upload a new build
+class API::BuildsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :authenticate
+
+  # Example Create Request:
+  # curl -X POST \
+  #   -H "Authorization: Token token=[mdma_token]" \
+  #   -H "Content-Type: multipart/form-data" \
+  #   -F "package=@[ipa_path]" \
+  #   -F "title=\"[title]\"" \
+  #   http://[host]/api/builds
+
+  def create
+    @build = Build.new(build_params)
+
+    if @build.save
+      render head: :ok
+    else
+      render json: { message: @build.errors.full_messages.first }, status: :bad_request
+    end
+  end
+
+private
+
+  def build_params
+    params.permit :title, :package
+  end
+
+  def authentication_token
+    ENV['MDMA_TOKEN']
+  end
+
+  def authenticate
+    return false if authentication_token.blank?
+
+    authenticate_or_request_with_http_token do |token, _|
+      ActiveSupport::SecurityUtils.secure_compare(token, authentication_token)
+    end
+  end
+end

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -23,6 +23,6 @@ class BuildsController < ApplicationController
 private
 
   def build_params
-    params.require(:build).permit :version, :deploy_date, :deploy_time, :package
+    params.require(:build).permit :title, :deploy_date, :deploy_time, :package
   end
 end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -18,6 +18,7 @@ class Build < ActiveRecord::Base
     validate_future_time if deploy_time.present?
   end
 
+  before_create :set_version
   before_create :set_deploy_at, if: -> { deploy_date.present? && deploy_time.present? }
   before_create :create_deploy, if: -> { deploy_at.present? }
 
@@ -32,6 +33,11 @@ class Build < ActiveRecord::Base
   end
 
 private
+
+  def set_version
+    info_plist = PackageAnalyzer.new(@build.package.blob).metadata
+    self.version = info_plist[:bundle_version]
+  end
 
   def validate_future_date
     self.deploy_date = Date.strptime deploy_date, '%Y-%m-%d'

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -18,9 +18,10 @@ class Build < ActiveRecord::Base
     validate_future_time if deploy_time.present?
   end
 
-  before_create :set_version
   before_create :set_deploy_at, if: -> { deploy_date.present? && deploy_time.present? }
   before_create :create_deploy, if: -> { deploy_at.present? }
+
+  before_validation :set_version, on: :create
 
   after_create_commit prepend: true do
     GenerateManifestJob.perform_later self
@@ -35,7 +36,7 @@ class Build < ActiveRecord::Base
 private
 
   def set_version
-    info_plist = PackageAnalyzer.new(@build.package.blob).metadata
+    info_plist = PackageAnalyzer.new(package.blob).metadata
     self.version = info_plist[:bundle_version]
   end
 

--- a/app/views/builds/new.html.erb
+++ b/app/views/builds/new.html.erb
@@ -11,14 +11,14 @@
     </div>
   <% end %>
 
-  <%= fieldset "2. Specify the version" do %>
+  <%= fieldset "2. Title (Optional)" do %>
     <div class="form-group">
-      <%= form.label :version, class: 'sr-only' %>
-      <% if @build.errors[:version].any? %>
-        <%= form.text_field :version, class: 'form-control is-invalid', placeholder: 'Version' %>
-        <div class="invalid-feedback"><%= @build.errors.full_messages_for(:version).to_sentence %>.</div>
+      <%= form.label :title, class: 'sr-only' %>
+      <% if @build.errors[:title].any? %>
+        <%= form.text_field :title, class: 'form-control is-invalid', placeholder: 'Title' %>
+        <div class="invalid-feedback"><%= @build.errors.full_messages_for(:title).to_sentence %>.</div>
       <% else %>
-        <%= form.text_field :version, class: 'form-control', placeholder: 'Version' %>
+        <%= form.text_field :title, class: 'form-control', placeholder: 'Title' %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/internal_builds/index.html.erb
+++ b/app/views/internal_builds/index.html.erb
@@ -3,6 +3,7 @@
   <thead>
     <tr>
       <th>Version</th>
+      <th>Title</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -11,6 +12,7 @@
     <% @builds.each do |build| %>
       <tr class="table-default">
         <td><%= build.version %></td>
+        <td><%= build.title %></td>
         <% if build.has_valid_manifest? %>
         <td>
           <%= link_to 'Install', manifest_url(build.manifest), class: "btn btn-link" %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'API' 
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,8 @@ Rails.application.routes.draw do
   resources :fetches, only: %i[create]
   resources :deploys, only: %i[destroy]
   root to: 'builds#index'
+
+  namespace :api do
+    resources :builds, only: %i[create]
+  end
 end

--- a/db/migrate/20191102001441_add_title_column_to_builds_table.rb
+++ b/db/migrate/20191102001441_add_title_column_to_builds_table.rb
@@ -1,0 +1,5 @@
+class AddTitleColumnToBuildsTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :builds, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_28_143030) do
+ActiveRecord::Schema.define(version: 2019_11_02_001441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2019_10_28_143030) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "version", null: false
+    t.string "title"
     t.index ["version"], name: "index_builds_on_version", unique: true
   end
 


### PR DESCRIPTION
A third-party client can now be used to make a request to upload a build. This can be used in place of the web interface in order to do things like upload a build automatically after a GitHub action is triggered. To use this functionality, a new `MDMA_TOKEN` environment variable must be set. Additionally, both the web interface and new API no longer take a version, rather the version is set automatically based on the version in the `info.plist` of the uploaded build. An optional title can now be set on the build as well.