### PR TITLE
Add ability to create builds through API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ The app is hosted on Heroku and relies on one job run by Heroku Scheduler every 
 A separate job is run on Heroku Scheduler every day.
 `bundle exec rake devices:fetch` fetches the list of devices with the latest app version.
 
+How to use as an API
+====================
+
+Apart from using the web flow, third-party clients can also create internal builds by means of an API.
+In order to do so, an option `MDMA_TOKEN` must be set in the mdma app and communicated to the third-party clients.
+Clients will use this token to submit requests like this:
+
+```
+curl -X POST \
+  -H "Authorization: Token token=[mdma token]" \
+  -F "build[package]=@[path to the IPA file]" \
+  [mdma host]/api/builds
+```
+
+and can expect one of the following responses:
+
+- 201 Created (no body): the file was uploaded and the internal build created
+- 401 Unauthorized (no body): the provided token is missing or invalid
+- 400 Bad Request (JSON body with "message" String): the params are invalid
+
+
 How to contribute
 =================
 
@@ -52,6 +73,7 @@ The following environment variables are optional:
 
 - `GITHUB_PROJECT`: The GitHub "username/project" path to fetch release notes from
 - `SLACK_CHANNEL`: The Slack channel to post notifications to (defaults to #deploys)
+- `MDMA_TOKEN`: An authorization token for third-party API clients
 
 For completeness, these are the credentials stored in the app:
 

--- a/app.json
+++ b/app.json
@@ -10,6 +10,9 @@
     "RAILS_MASTER_KEY": {
       "required": true
     },
+    "MDMA_TOKEN": {
+      "generator": "secret"
+    },
     "REDIS_PROVIDER": {
       "required": true
     }

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,17 @@
+# Base controller for third-party API requests.
+class API::ApplicationController < ActionController::Base
+  skip_before_action :verify_authenticity_token
+  before_action :require_api_authentication
+
+private
+
+  rescue_from ActionController::ParameterMissing do |error|
+    render json: { message: error.message }, status: :bad_request
+  end
+
+  def require_api_authentication
+    authenticate_or_request_with_http_token do |token, _options|
+      ActiveSupport::SecurityUtils.secure_compare token, ENV.fetch('MDMA_TOKEN', '')
+    end
+  end
+end

--- a/app/controllers/api/builds_controller.rb
+++ b/app/controllers/api/builds_controller.rb
@@ -1,0 +1,18 @@
+# Exposes an endpoint for third-party APIs to create internal builds.
+class API::BuildsController < API::ApplicationController
+  def create
+    build = Build.new(build_params)
+
+    if build.save
+      head :created
+    else
+      render json: { message: build.error_message }, status: :bad_request
+    end
+  end
+
+private
+
+  def build_params
+    params.require(:build).permit :package
+  end
+end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -39,6 +39,10 @@ class Build < ActiveRecord::Base
     deploy_at.present?
   end
 
+  def error_message
+    errors.full_messages.to_sentence
+  end
+
 private
 
   def set_version

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'API'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,8 @@ Rails.application.routes.draw do
   resources :fetches, only: %i[create]
   resources :deploys, only: %i[destroy]
   root to: 'builds#index'
+
+  namespace :api, defaults: { format: :json }, constraints: lambda { |req| req.format == :json } do
+    resources :builds, only: %i[create]
+  end
 end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe 'Creating a build via the API' do
+  before { post api_builds_url, headers: headers, params: params }
+  let(:headers) { {} }
+  let(:params) { {} }
+
+  context 'without an authorization token' do
+    it { expect(response).to be_unauthorized }
+  end
+
+  context 'with an authorization token' do
+    let(:headers) { { Authorization: "Token token=#{token}" } }
+    ENV['MDMA_TOKEN'] = SecureRandom.hex
+
+    context 'that does not match the expected token' do
+      let(:token) { 'something-else' }
+      it { expect(response).to be_unauthorized }
+    end
+
+    context 'that matches the expected token' do
+      let(:token) { ENV['MDMA_TOKEN'] }
+
+      context 'with a file' do
+        let(:params) { { build: { package: file_content } } }
+
+        context 'that is a valid IPA' do
+          let(:file_content) { fixture_file_upload file_fixture('demo_v42.ipa') }
+          it { expect(response).to be_created }
+        end
+
+        context 'that is not a valid IPA' do
+          let(:file_content) { fixture_file_upload file_fixture('empty.png') }
+          it { expect(response).to be_bad_request }
+          it { expect(JSON(response.body)['message']).to be_a String }
+        end
+      end
+
+      context 'without a file' do
+        it { expect(response).to be_bad_request }
+        it { expect(JSON(response.body)['message']).to be_a String }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracted from #167 to only focus on the API component,
adding tests and removing the changes to version and title.

Closes #167 -- to be rebased after #170 