### PR TITLE
Display clearer validation messages for builds

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -13,8 +13,10 @@ class Build < ActiveRecord::Base
 
   scope :with_attachments, -> { with_attached_package.with_attached_manifest }
 
-  before_validation :set_version, on: :create, if: -> { package.attached? }
-  validates :version, presence: true, uniqueness: true
+  with_options if: -> { package.attached? } do
+    before_validation :set_version, on: :create
+    validates :version, uniqueness: true
+  end
 
   attr_accessor :deploy_date, :deploy_time
   validate on: :create do


### PR DESCRIPTION
Before this commit we would display two validation errors when one was sufficient:

<img width="475" alt="Screen Shot 2019-12-04 at 3 18 12 PM" src="https://user-images.githubusercontent.com/32649767/70190961-381f9000-16ac-11ea-8872-1823c1a95570.png">

After this commit, we take advantage of `with_options` ([see docs](https://api.rubyonrails.org/classes/Object.html#method-i-with_options)) to display just one error:

<img width="340" alt="Screen Shot 2019-12-04 at 3 16 35 PM" src="https://user-images.githubusercontent.com/32649767/70190976-3f469e00-16ac-11ea-9bf2-2866ff161545.png">
<img width="304" alt="Screen Shot 2019-12-04 at 3 17 54 PM" src="https://user-images.githubusercontent.com/32649767/70190977-3f469e00-16ac-11ea-999e-b69e5fe010d1.png">
