### PR TITLE
Don't display Puma log in RSpec output

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,9 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 
+require 'action_dispatch/system_testing/server'
+ActionDispatch::SystemTesting::Server.silence_puma = true
+
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|


### PR DESCRIPTION
See https://github.com/rspec/rspec-rails/issues/1897

*Before*

<img width="432" alt="Screen Shot 2019-12-05 at 11 49 07 AM" src="https://user-images.githubusercontent.com/32649767/70268478-660cdf00-1755-11ea-82b5-5aed71d78ab2.png">


*After*

<img width="444" alt="Screen Shot 2019-12-05 at 11 49 01 AM" src="https://user-images.githubusercontent.com/32649767/70268487-69a06600-1755-11ea-9013-cfc5dfc105ec.png">
