### PR TITLE
Move the allowed email domains from code to ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ In order to use `mdma`, the following environment variables need to be set:
 
 The following environment variables are optional:
 
+- `EMAIL_DOMAIN`: Only allow logins from Google accounts belonging to this domain
 - `GITHUB_PROJECT`: The GitHub "username/project" path to fetch release notes from
 - `SLACK_CHANNEL`: The Slack channel to post notifications to (defaults to #deploys)
 - `MDMA_TOKEN`: An authorization token for third-party API clients

--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
     "postdeploy": "bundle exec rails db:migrate"
   },
   "env": {
+    "EMAIL_DOMAIN": "@clutter.com",
     "MDMA_APP_GROUP_ID": "21707",
     "MDMA_APP_ID": "91051",
     "MDMA_APP_IDENTIFIER": "com.clutter.UglySweater",

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,7 @@ class SessionsController < ApplicationController
 
   def auth
     auth = Yt::Auth.create redirect_uri: auth_sessions_url, code: params[:code]
-    if auth.email.ends_with? '@clutter.com'
+    if auth.email.ends_with? ENV.fetch('EMAIL_DOMAIN', '')
       session[:logged_in] = true
       redirect_to root_url
     else

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
 <p class='text-center'>
   <%= notice %><br />
-  <%= link_to "Log in with your clutter.com email", google_auth_url %>
+  <%= link_to "Log in with your #{ENV['EMAIL_DOMAIN']} email".squish, google_auth_url %>
 </p>

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -2,6 +2,6 @@ RSpec.describe 'The home-page' do
   before { visit root_url }
 
   it 'displays a link to log in' do
-    expect(page).to have_link('Log in with your clutter.com email')
+    expect(page).to have_link('Log in with your email')
   end
 end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Logging in' do
   before { login_as email }
 
-  context 'as a non-Clutter user' do
+  context 'from an unauthorized domain' do
     let(:email) { 'test@example.com' }
 
     it 'displays an authentication error' do
@@ -9,7 +9,7 @@ RSpec.describe 'Logging in' do
     end
   end
 
-  context 'as a Clutter user' do
+  context 'from an authorized domain' do
     let(:email) { 'test@clutter.com' }
 
     it 'displays the app' do
@@ -21,6 +21,7 @@ end
 private
 
 def login_as(email)
+  ENV['EMAIL_DOMAIN'] = '@clutter.com'
   authentication = double
   expect(authentication).to receive(:email).and_return email
   expect(Yt::Auth).to receive(:create).and_return(authentication)


### PR DESCRIPTION
To keep a clean separation between open-source code and Clutter-
specific application, the hard-coded "@clutter.com" has been
moved into an ENV, which can be set to a different value by
different companies.

We are still keeping its value to "@clutter.com" in app.json to
make it work in Review Apps. The ENV has also already been set
in the current production applications.