### PR TITLE
Add ability to set minimum required version for build

### DIFF
--- a/app/controllers/builds/minimum_supported_versions_controller.rb
+++ b/app/controllers/builds/minimum_supported_versions_controller.rb
@@ -1,0 +1,12 @@
+module Builds
+  # Controller to handle setting the build that is the minimum supported version.
+  class MinimumSupportedVersionsController < ApplicationController
+    before_action :require_authentication
+
+    # /builds/:id/minimum_supported_version
+    def update
+      Build.find(params[:build_id]).update!(minimum_supported_version: true)
+      redirect_back fallback_location: root_path, notice: 'New minimum supported version.'
+    end
+  end
+end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -31,6 +31,9 @@ class Build < ActiveRecord::Base
     GenerateManifestJob.perform_later self
   end
 
+  after_update :handle_new_minimum_supported_version,
+               if: -> { minimum_supported_version && saved_change_to_minimum_supported_version? }
+
   MANIFEST_EXPIRES_IN = 1.week
 
   def with_valid_manifest?
@@ -75,5 +78,9 @@ private
 
   def create_deploy
     self.deploy = Deploy.new
+  end
+
+  def handle_new_minimum_supported_version
+    Build.where.not(id: id).where(minimum_supported_version: true).update_all(minimum_supported_version: false)
   end
 end

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:refresh) { refresh_button_to 'Enqueue pending', enqueues_path } %>
-<table class="table table-sm">
+<table class="table table-sm text-center">
   <thead>
     <tr>
       <th>Version</th>
@@ -11,21 +11,26 @@
 
   <tbody>
     <% @builds.each do |build| %>
-      <tr class="table-default">
+      <tr class="table-default text-center">
         <td><%= build.version %></td>
         <td>
           on <%= l build.deploy_at.in_time_zone, format: :verbose %>
         </td>
         <td></td>
-        <% if build.with_valid_manifest? %>
         <td>
-          <%= link_to 'Install', manifest_url(build.manifest), class: "btn btn-link" %>
+          <% if build.with_valid_manifest? %>
+            <%= link_to 'Install', manifest_url(build.manifest), class: "btn btn-link" %>
+          <% else %>
+            <%= link_to 'Download', rails_blob_url(build.package, disposition: 'attachment') %>
+          <% end %>
+          <% if build.minimum_supported_version %>
+            Minimum Supported Version
+          <% else %>
+            <span class="d-inline-block">
+              <%= button_to 'Set As Minimum Supported', build_minimum_supported_version_url(build_id: build.id), method: :put, remote: false, class: "btn btn-primary" %>
+            </span>
+          <% end %>
         </td>
-        <% else %>
-        <td>
-          <%= link_to 'Download', rails_blob_url(build.package, disposition: 'attachment') %>
-        </td>
-        <% end %>
       </tr>
       <tr class="<%= table_class_for(build.deploy) %>">
         <td></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   resource :sessions, only: %i[new] do
     get 'auth', on: :member
   end
-  resources :builds, only: %i[new create]
+  resources :builds, only: %i[new create] do
+    scope module: 'builds' do
+      resource :minimum_supported_version, only: :update
+    end
+  end
   resources :internal_builds, only: %i[index]
   resources :enqueues, only: %i[create]
   resources :devices, only: %i[index]

--- a/db/migrate/20200929185128_add_minimum_supported_version_to_device.rb
+++ b/db/migrate/20200929185128_add_minimum_supported_version_to_device.rb
@@ -1,0 +1,9 @@
+class AddMinimumSupportedVersionToDevice < ActiveRecord::Migration[6.0]
+  def change
+    add_column :builds, :minimum_supported_version, :boolean, default: false
+
+    reversible do |dir|
+      dir.up { Build.external.order(id: :asc).first&.update_column(:minimum_supported_version, true) }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_28_143030) do
+ActiveRecord::Schema.define(version: 2020_09_29_185128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2019_10_28_143030) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "version", null: false
+    t.boolean "minimum_supported_version", default: false
     t.index ["version"], name: "index_builds_on_version", unique: true
   end
 


### PR DESCRIPTION

## Context
This gives the ability to specificy the minimum supported version of an app. Necessary groundwork to start enforcing app versions to be updated to at least a certain point.


<img width="1131" alt="Screen Shot 2020-09-29 at 1 25 13 PM" src="https://user-images.githubusercontent.com/40773985/94611976-4e0fca00-0257-11eb-8406-cd41582f17e6.png">
