### PR TITLE
Expose recommended versions api endpoint

### DIFF
--- a/app/controllers/api/builds/recommended_versions_controller.rb
+++ b/app/controllers/api/builds/recommended_versions_controller.rb
@@ -1,0 +1,31 @@
+module API
+  module Builds
+    # Exposes an endpoint for third-party APIs to see the recommended build version.
+    class RecommendedVersionsController < BaseController
+      def show
+        render(
+          json: {
+            current_version: latest_build&.version,
+            minimum_supported_version: minimum_supported_build.version,
+            manifest_url: manifest_url
+          },
+          status: :ok
+        )
+      end
+
+    private
+
+      def latest_build
+        @latest_build ||= Build.latest_deployed.first
+      end
+
+      def minimum_supported_build
+        Build.find_by(minimum_supported_version: true)
+      end
+
+      def manifest_url
+        latest_build ? helpers.manifest_url(latest_build.manifest) : nil
+      end
+    end
+  end
+end

--- a/app/controllers/builds/minimum_supported_versions_controller.rb
+++ b/app/controllers/builds/minimum_supported_versions_controller.rb
@@ -1,0 +1,12 @@
+module Builds
+  # Controller to handle setting the build that is the minimum supported version.
+  class MinimumSupportedVersionsController < ApplicationController
+    before_action :require_authentication
+
+    # /builds/:id/minimum_supported_version
+    def update
+      Build.find(params[:build_id]).update!(minimum_supported_version: true)
+      redirect_back fallback_location: root_path, notice: 'New minimum supported version.'
+    end
+  end
+end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -31,6 +31,9 @@ class Build < ActiveRecord::Base
     GenerateManifestJob.perform_later self
   end
 
+  after_update :handle_new_minimum_supported_version,
+               if: -> { minimum_supported_version && saved_change_to_minimum_supported_version? }
+
   MANIFEST_EXPIRES_IN = 1.week
 
   def with_valid_manifest?
@@ -75,5 +78,9 @@ private
 
   def create_deploy
     self.deploy = Deploy.new
+  end
+
+  def handle_new_minimum_supported_version
+    Build.where.not(id: id).where(minimum_supported_version: true).update_all(minimum_supported_version: false)
   end
 end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -10,6 +10,9 @@ class Build < ActiveRecord::Base
 
   scope :external, -> { where.not(deploy_at: nil) }
   scope :internal, -> { where(deploy_at: nil) }
+  scope :latest_deployed, lambda {
+    joins(:deploy).where(deploys: { status: %i[enqueued running successful] }).order(:deploy_at)
+  }
 
   scope :with_attachments, -> { with_attached_package.with_attached_manifest }
 

--- a/app/views/builds/index.html.erb
+++ b/app/views/builds/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:refresh) { refresh_button_to 'Enqueue pending', enqueues_path } %>
-<table class="table table-sm">
+<table class="table table-sm text-center">
   <thead>
     <tr>
       <th>Version</th>
@@ -11,21 +11,26 @@
 
   <tbody>
     <% @builds.each do |build| %>
-      <tr class="table-default">
+      <tr class="table-default text-center">
         <td><%= build.version %></td>
         <td>
           on <%= l build.deploy_at.in_time_zone, format: :verbose %>
         </td>
         <td></td>
-        <% if build.with_valid_manifest? %>
         <td>
-          <%= link_to 'Install', manifest_url(build.manifest), class: "btn btn-link" %>
+          <% if build.with_valid_manifest? %>
+            <%= link_to 'Install', manifest_url(build.manifest), class: "btn btn-link" %>
+          <% else %>
+            <%= link_to 'Download', rails_blob_url(build.package, disposition: 'attachment') %>
+          <% end %>
+          <% if build.minimum_supported_version %>
+            Minimum Supported Version
+          <% else %>
+            <span class="d-inline-block">
+              <%= button_to 'Set As Minimum Supported', build_minimum_supported_version_url(build_id: build.id), method: :put, remote: false, class: "btn btn-primary" %>
+            </span>
+          <% end %>
         </td>
-        <% else %>
-        <td>
-          <%= link_to 'Download', rails_blob_url(build.package, disposition: 'attachment') %>
-        </td>
-        <% end %>
       </tr>
       <tr class="<%= table_class_for(build.deploy) %>">
         <td></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   resource :sessions, only: %i[new] do
     get 'auth', on: :member
   end
-  resources :builds, only: %i[new create]
+  resources :builds, only: %i[new create] do
+    scope module: 'builds' do
+      resource :minimum_supported_version, only: :update
+    end
+  end
   resources :internal_builds, only: %i[index]
   resources :enqueues, only: %i[create]
   resources :devices, only: %i[index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     get 'auth', on: :member
   end
   resources :builds, only: %i[new create] do
-    scope module: 'builds' do
+    scope module: :builds do
       resource :minimum_supported_version, only: :update
     end
   end
@@ -16,5 +16,8 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json }, constraints: lambda { |req| req.format == :json } do
     resources :builds, only: %i[create]
+    namespace :builds do
+      resource :recommended_versions, only: :show, constraints: { format: 'json' }
+    end
   end
 end

--- a/db/migrate/20200929185128_add_minimum_supported_version_to_device.rb
+++ b/db/migrate/20200929185128_add_minimum_supported_version_to_device.rb
@@ -1,0 +1,9 @@
+class AddMinimumSupportedVersionToDevice < ActiveRecord::Migration[6.0]
+  def change
+    add_column :builds, :minimum_supported_version, :boolean, default: false
+
+    reversible do |dir|
+      dir.up { Build.external.order(id: :asc).first&.update_column(:minimum_supported_version, true) }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_28_143030) do
+ActiveRecord::Schema.define(version: 2020_09_29_185128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2019_10_28_143030) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "version", null: false
+    t.boolean "minimum_supported_version", default: false
     t.index ["version"], name: "index_builds_on_version", unique: true
   end
 

--- a/lib/tasks/refresh_manifest_file.rake
+++ b/lib/tasks/refresh_manifest_file.rake
@@ -1,0 +1,8 @@
+namespace :builds do
+  # Meant to run every day with Heroku Scheduler
+  desc 'Refresh the manifest file for a build since the URL expires weekly'
+  task refresh_latest_manifest: :environment do
+    latest = Build.latest_deployed.first
+    GenerateManifestJob.perform_later(latest) if latest
+  end
+end


### PR DESCRIPTION
Review just last commit, first one is being reviewed https://github.com/clutter/mdma/pull/189

## Context
Now that we can set the minimum required version that the app says it can support, we should expose this info in within API endpoints for other parties to read and act upon

We also want to periodically refresh the manifest file of the latest build since the install link has a 1 week expiration on it. The rake task is meant to be run in a heroku scheduler twice a week to circumvent this.