### PR TITLE
Run refresh only twice a week and builds order correctly

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -11,7 +11,7 @@ class Build < ActiveRecord::Base
   scope :external, -> { where.not(deploy_at: nil) }
   scope :internal, -> { where(deploy_at: nil) }
   scope :latest_deployed, lambda {
-    joins(:deploy).where(deploys: { status: %i[enqueued running successful] }).order(:deploy_at)
+    joins(:deploy).where(deploys: { status: %i[enqueued running successful] }).order(deploy_at: :desc)
   }
 
   scope :with_attachments, -> { with_attached_package.with_attached_manifest }

--- a/lib/tasks/refresh_manifest_file.rake
+++ b/lib/tasks/refresh_manifest_file.rake
@@ -2,7 +2,9 @@ namespace :builds do
   # Meant to run every day with Heroku Scheduler
   desc 'Refresh the manifest file for a build since the URL expires weekly'
   task refresh_latest_manifest: :environment do
-    latest = Build.latest_deployed.first
-    GenerateManifestJob.perform_later(latest) if latest
+    if Time.now.wednesday? || Time.now.sunday? # Only run twice a week
+      latest = Build.latest_deployed.first
+      GenerateManifestJob.perform_later(latest) if latest
+    end
   end
 end


### PR DESCRIPTION
Heroku scheduler only allows daily runs or every 10 mins, so guarding the task to only run on wednesdays and sundays

also order the builds correctly in descending order of last deployed at build