### PR TITLE
Log Sorbet runtime errors instead of raising

### DIFF
--- a/config/initializers/sorbet.rb
+++ b/config/initializers/sorbet.rb
@@ -1,0 +1,15 @@
+T::Configuration.inline_type_error_handler = lambda do |error|
+  Rails.logger.error error.message
+end
+
+T::Configuration.call_validation_error_handler = lambda do |_signature, opts|
+  Rails.logger.error opts[:message]
+end
+
+T::Configuration.sig_builder_error_handler = lambda do |error, _location|
+  Rails.logger.error error.message
+end
+
+T::Configuration.sig_validation_error_handler = lambda do |error, _opts|
+  Rails.logger.error error.message
+end


### PR DESCRIPTION
Log errors rather than raising. Configuration is in `config/initializers/sorbet.rb`

Helpful documentation:
https://sorbet.org/docs/tconfiguration

Alerts can be added for the errors, which will look like:
![image](https://user-images.githubusercontent.com/47334340/105104411-09f34000-5a67-11eb-87e3-723ec025c791.png)

tested using:

```ruby
class SessionsController < ApplicationController
  def new
    x = T.let(2, String)
  end
   ...
end
```
