### PR TITLE
Fix typo in manifest file

### DIFF
--- a/app/jobs/generate_manifest_job.rb
+++ b/app/jobs/generate_manifest_job.rb
@@ -49,7 +49,7 @@ private
             <key>metadata</key>
             <dict>
               <key>bundle-identifier</key>
-              <string>#{@info_plist[:bundle_version]}</string>
+              <string>#{@info_plist[:bundle_identifier]}</string>
               <key>bundle-version</key>
               <string>#{@info_plist[:bundle_short_version]}</string>
               <key>kind</key>


### PR DESCRIPTION
Versions of iOS prior to iOS 16 were ignoring the bundle-identifier value in the manifest.plist. Since it is now being checked we need to set it to the correct version.

[Fix MDMA to address iOS 16 OTA install bug](https://www.pivotaltracker.com/story/show/183334533)